### PR TITLE
Fix NULL dereference error on Momentum 009 FW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.1 (2025-02-07)
+
+## Bug-fixes
+- Sending NULL to file browser extension filtering caused intermittent problems on OFW, but completely breaks on Momentum 009 with NULL dereference error. Fixed & tested on Original and M009 firmwares.
+
 # v2.0 (2025-02-05)
 
 ## New Features

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This app is tested against the current `dev` and `release` branches of the [OFW]
 * Current OFW Version: 1.2.0
 <br>[![Compatibility status:](https://github.com/shalebridge/flipper-subghz-scheduler/actions/workflows/build.yml/badge.svg)](https://github.com/shalebridge/flipper-subghz-scheduler/actions/workflows/build.yml)
 
+It has also been tested against [Momentum 009](https://github.com/Next-Flip/Momentum-Firmware/releases/tag/mntm-009).
+
 ## Build
 
 These apps are built using [ufbt](https://pypi.org/project/ufbt/) - a subset of the flipper build tool (fbt) targeted at building apps. Install it with:

--- a/application.fam
+++ b/application.fam
@@ -7,7 +7,7 @@ App(
     entry_point="scheduler_app",
     stack_size=2 * 1024,
     fap_category="Sub-GHz",
-    fap_version="2.0",
+    fap_version="2.1",
     fap_icon="icons/icon.png",  # 10x10 1-bit PNG
     fap_icon_assets="icons",  # Image assets to compile for this application
     fap_author="Patrick Edwards",

--- a/scenes/scheduler_scene_loadfile.c
+++ b/scenes/scheduler_scene_loadfile.c
@@ -29,21 +29,12 @@ static int count_playlist_items(Storage* storage, const char* file_path) {
     return count;
 }
 
-bool check_file_extension(const char* filename) {
-    const char* extension = strrchr(filename, '.');
-    if(extension == NULL) {
-        return false;
-    } else {
-        return !strcmp(extension, ".txt") || !strcmp(extension, ".sub");
-    }
-}
-
 static bool load_protocol_from_file(SchedulerApp* app) {
     furi_assert(app);
     FuriString* file_path = furi_string_alloc();
     Storage* storage = furi_record_open(RECORD_STORAGE);
     DialogsFileBrowserOptions browser_options;
-    dialog_file_browser_set_basic_options(&browser_options, NULL, &I_sub1_10px);
+    dialog_file_browser_set_basic_options(&browser_options, ".sub|.txt", &I_sub1_10px);
     browser_options.base_path = SUBGHZ_APP_FOLDER;
     furi_string_set(app->file_path, SUBGHZ_APP_FOLDER);
 
@@ -53,11 +44,8 @@ static bool load_protocol_from_file(SchedulerApp* app) {
 
     const char* filestr = furi_string_get_cstr(app->file_path);
     if(res) {
-        if(check_file_extension(filestr)) {
-            int8_t list_count = count_playlist_items(storage, filestr);
-
-            scheduler_set_file(app->scheduler, filestr, list_count);
-        }
+        int8_t list_count = count_playlist_items(storage, filestr);
+        scheduler_set_file(app->scheduler, filestr, list_count);
     }
 
     furi_record_close(RECORD_STORAGE);

--- a/scenes/scheduler_scene_loadfile.h
+++ b/scenes/scheduler_scene_loadfile.h
@@ -1,2 +1,2 @@
-
-bool check_file_extension(const char* filename);
+#pragma once
+//bool check_file_extension(const char* filename);

--- a/scenes/scheduler_scene_start.c
+++ b/scenes/scheduler_scene_start.c
@@ -88,7 +88,7 @@ void scheduler_scene_start_on_enter(void* context) {
     scheduler_set_tx_delay(app->scheduler, value_index);
 
     item = variable_item_list_add(var_item_list, "Select File", 0, NULL, app);
-    if(check_file_extension(furi_string_get_cstr(app->file_path))) {
+    if(!furi_string_empty(app->file_path)) {
         scene_manager_set_scene_state(
             app->scene_manager, SchedulerSceneStart, SchedulerStartRunEvent);
         if(scheduler_get_file_type(app->scheduler) == SchedulerFileTypeSingle) {
@@ -117,7 +117,7 @@ bool scheduler_scene_start_on_event(void* context, SceneManagerEvent event) {
 
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SchedulerStartRunEvent) {
-            if(!check_file_extension(furi_string_get_cstr(app->file_path))) {
+            if(furi_string_empty(app->file_path)) {
                 dialog_message_show_storage_error(
                     app->dialogs, "Please select\nplaylist (*.txt) or\n *.sub file!");
             } else {


### PR DESCRIPTION
Sending NULL to file browser extension filtering caused intermittent problems on OFW, but completely breaks on Momentum 009 with NULL dereference error. Fixed & tested on Original and M009 firmwares.